### PR TITLE
FIX: Undefined variable $num

### DIFF
--- a/htdocs/adherents/type.php
+++ b/htdocs/adherents/type.php
@@ -145,6 +145,7 @@ if ($action == 'add' && $user->rights->adherent->configurer) {
 		$sql = "SELECT libelle FROM ".MAIN_DB_PREFIX."adherent_type WHERE libelle='".$db->escape($object->label)."'";
 		$sql .= " WHERE entity IN (".getEntity('member_type').")";
 		$result = $db->query($sql);
+		$num = null;
 		if ($result) {
 			$num = $db->num_rows($result);
 		}


### PR DESCRIPTION
FIX Undefined variable in adherent module : $num
When creating new type of adherent, the undefined variable $num reports a warning.